### PR TITLE
Update the style of history list

### DIFF
--- a/src/components/DevReportCard.vue
+++ b/src/components/DevReportCard.vue
@@ -1,60 +1,105 @@
-
 <template>
-<el-card v-for="report in ticket.dev_reports" :key="report.id" style="margin-bottom:6px;">
-  <div style="display:flex; justify-content:space-between; gap:12px;">
+  <el-collapse accordion v-if="ticket.dev_reports && ticket.dev_reports.length > 0">
+    <el-collapse-item
+      v-for="report in ticket.dev_reports"
+      :key="report.id"
+      :name="report.id"
+    >
+      <!-- Header -->
+      <template #title>
+        <el-space alignment="center">
+          <div style="font-weight: 600">{{ report.assignedDeveloper.fullName }}</div>
+          <div style="color: #666; font-size: 13px; margin-top: 2px">
+            · Submitted: {{ new Date(report.created_at).toLocaleString() }} · Regression
+            Version:
+          </div>
+          <el-tag type="info" size="small"> {{ report.regression_version }} </el-tag>
+        </el-space>
+      </template>
 
-    <div>
-      <div style="font-weight:600;">
-        {{ report.assignedDeveloper.fullName }}
-      </div>
+      <!-- Content -->
+      <el-card shadow="never" class="mb-3">
+        <div class="flex justify-between items-center mb-3">
+          <el-descriptions :column="2" size="small" border label-width="110px">
+            <el-descriptions-item label="Module">
+              {{ report.module || "N/A" }}
+            </el-descriptions-item>
 
-      <div style="color:#666; font-size:13px; margin-top:2px;">
-        Issue Type: {{ report.issue_type }} <br>
-        Submitted: {{ new Date(report.created_at).toLocaleString() }}
-      </div>
+            <el-descriptions-item label="Issue Type">
+              {{ report.issue_type }}
+            </el-descriptions-item>
 
-      <div style="margin-top:8px; color:#444;">
-        Root Cause: {{ report.root_cause || "No Root Cause Provided" }}
-      </div>
+            <el-descriptions-item label="Root Cause">
+              {{ report.root_cause || "N/A" }}
+            </el-descriptions-item>
 
-      <div style="margin-top:8px; color:#444;">
-        Self Test Report: {{ report.self_test_report || "No Self Test Report" }}
-      </div>
+            <el-descriptions-item label="GitHub PR">
+              <el-link
+                v-if="report.github_pr_url"
+                :href="report.github_pr_url"
+                target="_blank"
+                type="primary"
+                style="font-weight: 500; font-size: 14px"
+              >
+                GitHub PR
+              </el-link>
+              <span v-else>N/A</span>
+            </el-descriptions-item>
+          </el-descriptions>
+        </div>
+        <el-row gutter="16" class="w-full" align="stretch">
+          <!-- Report -->
+          <el-col :span="14">
+        <h4>Developer Report</h4>
+            <el-card shadow="never" style="height: 200px; background: var(--el-fill-color-light); border-radius: 6px; " >
+              <el-scrollbar style="height: 100%">
+                <pre
+                  style="
+                    margin: 0;
+                    white-space: pre-wrap;
+                    font-family: var(--el-font-family);
+                    font-size: 13px;
+                    line-height: 1.6;
+                    color: var(--el-text-color-primary);
+                  "
+                  >{{ report.self_test_report }}</pre
+                >
+              </el-scrollbar>
+            </el-card>
+          </el-col>
 
-      <div v-if="report.self_test_screenshots" style="margin-top:8px;">
-          <el-image
-            style="width: 120px; border-radius:4px;"
-            :src="getShotURL(report.self_test_screenshots)"
-            fit="cover"
-          />
-      </div>
+          <!-- Screenshot -->
+          <el-col :span="10" v-if="report.self_test_screenshots">
+        <h4>Screenshot</h4>
+            <el-image
+              :src="getShotURL(report.self_test_screenshots)"
+              fit="cover"
+              style="width: 100%; height: 200px; border-radius: 6px; cursor: pointer"
+              @click="previewUrl = getShotURL(report.self_test_screenshots)"
+            />
+          </el-col>
+        </el-row>
+      </el-card>
 
-      <div v-if="report.github_pr_url" style="margin-top:8px;">
-        <a :href="report.github_pr_url" target="_blank" style="font-size:13px;color:#409EFF;">
-          GitHub PR
-        </a>
-      </div>
-    </div>
-
-    <div style="text-align:right;">
-      <el-tag type="info" size="small">
-        v{{ report.regression_version }}
-      </el-tag>
-
-      <div v-if="report.module" style="margin-top:6px; color:#888;font-size:12px;">
-        {{ report.module }}
-      </div>
-    </div>
-  </div>
-</el-card>
-
+      <!-- Image preview -->
+      <el-image-viewer
+        v-if="previewUrl"
+        :url-list="[previewUrl]"
+        @close="previewUrl = null"
+      />
+    </el-collapse-item>
+  </el-collapse>
 </template>
+
 <script setup lang="ts">
-import type { Ticket } from '../types'
-const props = defineProps<{ ticket: Ticket }>()
+import type { Ticket } from "../types";
+import { ref } from "vue";
+const props = defineProps<{ ticket: Ticket }>();
+
+const previewUrl = ref<string | null>(null);
 
 function getShotURL(shoturl: string) {
-  return `/api/${shoturl}`
+  return `/api/${shoturl}`;
 }
-
 </script>
+<style scoped></style>

--- a/src/components/QAReviewCard.vue
+++ b/src/components/QAReviewCard.vue
@@ -1,29 +1,47 @@
-
 <template>
-<el-card v-for="review in ticket.qa_reviews" :key="review?.id" style="margin-bottom:6px;">
-  <div style="display:flex; justify-content:space-between; gap:12px;">
-    <div>
-      <div style="font-weight:600;">{{ review.reviewer.fullName }}</div>
-      <div style="color:#666; font-size:13px; margin-top:2px;">
-        Submitted:{{ new Date(review.created_at).toLocaleString() }}
-      </div>
-      <div style="margin-top:8px; color:#444;">{{ review?.comment || "No comment" }}</div>
-    </div>
+  <el-collapse accordion v-if="ticket.qa_reviews && ticket.qa_reviews.length > 0">
+    <el-collapse-item
+      v-for="review in ticket.qa_reviews"
+      :key="review.id"
+      :name="review.id"
+    >
+      <!-- Header -->
+      <template #title>
+        <el-space alignment="center">
+          <div style="font-weight: 600">{{ review.reviewer.fullName }}</div>
+          <div style="color: #666; font-size: 13px; margin-top: 2px">
+            · Submitted: {{ new Date(review.created_at).toLocaleString() }} · 
+            <el-tag :type="review?.agree_to_release ? 'success' : 'danger'" size="small">
+              {{ review?.agree_to_release ? "Approved" : "Rejected" }}
+            </el-tag>
+          </div>
+        </el-space>
+      </template>
 
-    <div style="text-align:right;">
-      <el-tag
-        :type="review?.agree_to_release ? 'success' : 'danger'"
-        size="small"
-      >
-        {{ review?.agree_to_release ? "Approved" : "Rejected" }}
-      </el-tag>
-    </div>
-  </div>
-</el-card>
+      <!-- Content -->
+      <el-card shadow="never" class="mb-2">
+        <h4 style="margin-top: 2px; margin-bottom: 8px;">QA Comment</h4>
+          <el-card shadow="never" style=" height: 200px; background: var(--el-fill-color-light); border-radius: 6px; " >
+            <el-scrollbar style="height: 100%">
+              <pre
+                style="
+                  margin: 0;
+                  white-space: pre-wrap;
+                  font-family: var(--el-font-family);
+                  font-size: 13px;
+                  line-height: 1.6;
+                  color: var(--el-text-color-primary);
+                "
+                >{{ review?.comment || "No comment" }}</pre
+              >
+            </el-scrollbar>
+        </el-card>
+      </el-card>
+    </el-collapse-item>
+  </el-collapse>
 </template>
 
 <script setup lang="ts">
-import type { Ticket } from '../types'
-const props = defineProps<{ ticket: Ticket }>()
-
+import type { Ticket } from "../types";
+const props = defineProps<{ ticket: Ticket }>();
 </script>

--- a/src/components/RegressionCard.vue
+++ b/src/components/RegressionCard.vue
@@ -1,26 +1,45 @@
 
 <template>
-<el-card v-for="regression in ticket.regression_tests" :key="regression?.id" style="margin-bottom:6px;">
-  <div style="display:flex; justify-content:space-between; gap:12px;">
-    <div>
-      <div style="font-weight:600;">{{ regression.tester.fullName }}</div>
-      <div style="color:#666; font-size:13px; margin-top:2px;">
-        Regression Version: {{ regression.regression_version }} <br> Submitted:
-        {{ new Date(regression.created_at).toLocaleString() }}
-      </div>
-      <div style="margin-top:8px; color:#444;">{{ regression?.report || "No Regression Report" }}</div>
-    </div>
+<el-collapse accordion v-if="ticket.regression_tests && ticket.regression_tests.length > 0">
+    <el-collapse-item
+      v-for="regression in ticket.regression_tests"
+      :key="regression.id"
+      :name="regression.id"
+    >
+      <!-- Header -->
+      <template #title>
+        <el-space alignment="center">
+          <div style="font-weight: 600">{{ regression.tester.fullName }}</div>
+          <div style="color: #666; font-size: 13px; margin-top: 2px">
+            · Submitted: {{ new Date(regression.created_at).toLocaleString() }} · 
+            <el-tag :type="regression?.passed ? 'success' : 'danger'" size="small">
+              {{ regression?.passed ? "Approved" : "Rejected" }}
+            </el-tag>
+          </div>
+        </el-space>
+      </template>
 
-    <div style="text-align:right;">
-      <el-tag
-        :type="regression?.passed ? 'success' : 'danger'"
-        size="small"
-      >
-        {{ regression?.passed ? "Approved" : "Rejected" }}
-      </el-tag>
-    </div>
-  </div>
-</el-card>
+      <!-- Content -->
+      <el-card shadow="never" class="mb-2">
+        <h4 style="margin-top: 2px; margin-bottom: 8px;">Test Report</h4>
+          <el-card shadow="never" style=" height: 200px; background: var(--el-fill-color-light); border-radius: 6px; " >
+            <el-scrollbar style="height: 100%">
+              <pre
+                style="
+                  margin: 0;
+                  white-space: pre-wrap;
+                  font-family: var(--el-font-family);
+                  font-size: 13px;
+                  line-height: 1.6;
+                  color: var(--el-text-color-primary);
+                "
+                >{{ regression?.report || "No comment" }}</pre
+              >
+            </el-scrollbar>
+        </el-card>
+      </el-card>
+    </el-collapse-item>
+  </el-collapse>
 </template>
 <script setup lang="ts">
 import type { Ticket } from '../types'


### PR DESCRIPTION
The front-end design for displaying historical data has been optimized and looks much better.👇
<img width="1343" height="783" alt="屏幕截图 2025-11-20 144721" src="https://github.com/user-attachments/assets/21ed58a8-c311-4f19-af2c-4c0f7f5450b5" />
<img width="1361" height="813" alt="屏幕截图 2025-11-20 144401" src="https://github.com/user-attachments/assets/2dec7c06-2310-4ec6-b705-8086acabaa04" />
<img width="1367" height="738" alt="屏幕截图 2025-11-20 144346" src="https://github.com/user-attachments/assets/0e5b4289-cf63-41e0-b293-ca51713d050e" />
