### PR TITLE
Optimize the role permission judgment logic.

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,15 +18,6 @@ export interface QAreview {
   reviewer: User
 }
 
-export interface QAreview {
-  id: string
-  agree_to_release: true
-  comment?: string
-  created_at: string
-  designatedTester: User
-  reviewer: User
-}
-
 export interface Regression {
   id: string
   regression_version: string

--- a/src/views/TicketDetail.vue
+++ b/src/views/TicketDetail.vue
@@ -93,29 +93,34 @@ async function submitRegression(r: any) {
 }
 
 const isDev = computed(() => {
-  return auth.user?.role === "DEVELOPER" && ticket.value?.current_status === "OPEN";
+  const user = auth.user;
+  return (
+    user?.role === "DEVELOPER" &&
+    (ticket.value?.current_status === "OPEN" || ticket.value?.current_status === "IN_MODIFICATION") &&
+    ticket.value?.assignee?.id === user.id
+  );
 });
 
 const isQA = computed(() => {
-  // QA can only review when ticket status is UNDER_REVIEW
-  return auth.user?.role === "QA" && ticket.value?.current_status === "UNDER_REVIEW";
+  const user = auth.user;
+  return (
+    user?.role === "QA" &&
+    ticket.value?.current_status === "UNDER_REVIEW"
+  );
 });
 
 const isTester = computed(() => {
-  // TESTER can only edit during IN_REGRESSION phase, ADMIN can operate except during CLOSED phase
-  const userRole = auth.user?.role;
+  const user = auth.user;
   const status = ticket.value?.current_status;
-  
-  if (userRole === "ADMIN") {
-    return true; // Admin can always operate
-  }
-  
-  if (userRole === "TESTER" && status === "IN_REGRESSION") {
-    return true;
-  }
 
-  return false;
+  const lastQAReview = ticket.value?.qa_reviews?.[ticket.value?.qa_reviews.length - 1];
+  return (
+    user?.role === "TESTER" &&
+    status === "IN_REGRESSION" &&
+    lastQAReview?.designatedTester?.id === user.id
+  );
 });
+
 
 
 const severityType = computed(() => {


### PR DESCRIPTION
Optimize the role permission judgment logic to ensure that developers and testers are the designated personnel; otherwise, they are not allowed to perform operations. When there are multiple employees in the same role, only the assigned employee is allowed to submit reports.